### PR TITLE
Try internal pull-up resistors instead of the external ones.

### DIFF
--- a/ReadSensors/ReadSensors.ino
+++ b/ReadSensors/ReadSensors.ino
@@ -101,6 +101,31 @@ void setup()
   pinMode(LED_D2,  OUTPUT);
   pinMode(LED_D1,  OUTPUT);
   pinMode(LED_D0,  OUTPUT);
+
+  // Use internal pullup resistors.
+  // Works at least on teensy LC, try changing 1 to 0 if it doesn't:
+#if 1
+  pinMode(REG, INPUT_PULLUP);
+  pinMode(D7,  INPUT_PULLUP);
+  pinMode(D6,  INPUT_PULLUP);
+  pinMode(D5,  INPUT_PULLUP);
+  pinMode(D4,  INPUT_PULLUP);
+  pinMode(D3,  INPUT_PULLUP);
+  pinMode(D2,  INPUT_PULLUP);
+  pinMode(D1,  INPUT_PULLUP);
+  pinMode(D0,  INPUT_PULLUP);
+#else
+  digitalWrite(REG, HIGH);
+  digitalWrite(D7,  HIGH);
+  digitalWrite(D6,  HIGH);
+  digitalWrite(D5,  HIGH);
+  digitalWrite(D4,  HIGH);
+  digitalWrite(D3,  HIGH);
+  digitalWrite(D2,  HIGH);
+  digitalWrite(D1,  HIGH);
+  digitalWrite(D0,  HIGH);
+#endif
+
   sendCardReport(REPORT_OK_BOOT, NULL, 0);
 }
 


### PR DESCRIPTION
The internal pull-up resistors are about 20-50 kOhms, seek for "I/O Pin Pull-up Resistor" on page 384 of the datasheet:
http://www.atmel.com/Images/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf
It's probably more than what was in the original circuit but it should work.

If it doesn't, you might have to change the value of CFG_SENSOR_THRESHOLD, those lines should help to understand how it's used:
https://github.com/honnet/punchcard_reader/blob/master/ReadSensors/ReadSensors.ino#L23
https://github.com/honnet/punchcard_reader/blob/master/ReadSensors/ReadSensors.ino#L281

The way to set the internal pull-up resistors can also be done differently, see the comment in the commit.
More about pullup resistors and analog pins in the "Pullup resistors" section:
https://www.arduino.cc/en/Reference/AnalogPins
